### PR TITLE
Document the correct env variables in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ This service requires to be configured using environment variables:
 $ export PORT=6000
 
 # Access token for the GitHub API (requires permissions to access the repository)
-# you can also use GITHUB_USERNAME and GITHUB_USERNAME
+# you can also use GITHUB_USERNAME and GITHUB_PASSWORD
 $ export GITHUB_TOKEN=...
 
 # ID for the GitHub repository
-$ export GITHUB_REPOSITORY=Username/MyApp
+$ export GITHUB_REPO=Username/MyApp
 
 # Authentication for the private API
 $ export API_USERNAME=hello


### PR DESCRIPTION
The README file mentions the wrong name for the GitHub environment variables which causes unnecessary trouble during setup.