### PR TITLE
Adding notes endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ It uses GitHub as a backend to store assets, and it can easily be deployed to He
 - :sparkles: Private API
 - :sparkles: Use it as a middleware: add custom analytics, authentication
 - :sparkles: Serve the perfect type of assets: `.zip` for Squirrel.Mac, `.nupkg` for Squirrel.Windows, `.dmg` for Mac users, ...
+- :sparkles: Release notes endpoint
+    - `/notes/:version`
 - :sparkles: Up-to-date releases (GitHub webhooks)
 
 #### Deploy it / Start it

--- a/lib/index.js
+++ b/lib/index.js
@@ -255,6 +255,27 @@ module.exports = function nuts(opts) {
         .fail(next);
     });
 
+    // Get release notes for a specific version
+    router.get('/notes/:version', function(req, res, next) {
+        var tag = req.params.version;
+
+        Q()
+        .then(function() {
+            if (!tag) throw new Error('Requires "version" parameter');
+
+            return versions.get(tag);
+        })
+        .then(function(version) {
+            if (!version) return res.status(404).send('Version not found');
+
+            res.status(200).send({
+                "notes": version.notes,
+                "pub_date": version.published_at.toISOString()
+            });
+        })
+        .fail(next);
+    });
+
     // GitHub webhook to refresh list of versions
     var webhookHandler = githubWebhook({
         path: '/refresh',


### PR DESCRIPTION
Adding a public notes endpoint so a client that updates can show release notes *after* an update through Squirrel.  Useful if a dev/app wants to show off release/version/feature notes on an "About" section.