### PR TITLE
Make GitHub auth credentials optional (for public repos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This service requires to be configured using environment variables:
 $ export PORT=6000
 
 # Access token for the GitHub API (requires permissions to access the repository)
+# If the repository is public you do not need to provide an access token
 # you can also use GITHUB_USERNAME and GITHUB_PASSWORD
 $ export GITHUB_TOKEN=...
 
@@ -203,4 +204,3 @@ var nuts = Nuts(
 app.use('/myapp', nuts);
 app.listen(4000);
 ```
-

--- a/lib/github.js
+++ b/lib/github.js
@@ -50,19 +50,27 @@ module.exports = function(opts) {
 
     // Stream a download to res
     var streamAsset = function (uri) {
+        var headers = {
+            'User-Agent': "releaser-server",
+            'Accept': "application/octet-stream"
+        };
+        var httpAuth = null;
+
+        if (opts.token) {
+          headers['Authorization'] = 'token '+opts.token;
+        } else if (opts.username) {
+          httpAuth = {
+            user: opts.username,
+            pass: opts.password,
+            sendImmediately: true
+          };
+        }
+
         return request({
             uri: uri,
             method: 'get',
-            headers: {
-                'User-Agent': "releaser-server",
-                'Accept': "application/octet-stream",
-                'Authorization': opts.token? 'token '+opts.token : undefined
-            },
-            auth: opts.token? undefined : {
-                user: opts.username,
-                pass: opts.password,
-                sendImmediately: true
-            }
+            headers: headers,
+            auth: httpAuth
         });
     };
 


### PR DESCRIPTION
When reading info and fetching releases from a public GH repo, there's no need for an access token. This commit makes it so that we leave off the Authorization header and HTTP auth fields when no token nor username & password are provided.

Tested against a public repo and Electron's autoupdater.