### PR TITLE
fixes squirrel 1.2.2 issues for windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -211,7 +211,6 @@ module.exports = function nuts(opts) {
         .then(function(versions) {
             // Update needed?
             var latest = _.first(versions);
-            if (!latest || latest.tag == tag) return res.status(204).send('No updates');
 
             // File exists
             var asset = _.find(latest.platforms, {


### PR DESCRIPTION
fix for https://github.com/GitbookIO/nuts/issues/18

Squirrel throws an Exception from the empty response:
https://github.com/Squirrel/Squirrel.Windows/blob/d6f83880ee6ebf068f1f2325c6f97255a237678c/src/Squirrel/UpdateManager.CheckForUpdates.cs#L124

This change skips the empty response and allows Squirrel to detect that it is the latest version.