### PR TITLE
Don't filter out old versions or -delta from the RELEASES file. Closes #22

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -226,7 +226,7 @@ module.exports = function nuts(opts) {
 
                     // Change filename to use download proxy
                     .map(function(entry) {
-                        entry.filename = url.resolve(fullUrl, '/download/'+latest.tag+'/'+entry.filename);
+                        entry.filename = url.resolve(fullUrl, '/download/'+entry.version+'/'+entry.filename);
 
                         return entry;
                     })

--- a/lib/index.js
+++ b/lib/index.js
@@ -224,12 +224,7 @@ module.exports = function nuts(opts) {
 
                 releases = _.chain(releases)
 
-                    // Exclude deltas and other versions
-                    .filter(function(entry) {
-                        return (!entry.isDelta && entry.version == winReleases.normVersion(latest.tag));
-                    })
-
-                    // Change filename to use downlaodp roxy
+                    // Change filename to use download proxy
                     .map(function(entry) {
                         entry.filename = url.resolve(fullUrl, '/download/'+latest.tag+'/'+entry.filename);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,7 +91,7 @@ module.exports = function nuts(opts) {
                 if (req.useragent.isLinux64) platform = platforms.LINUX_64;
             }
 
-            if (!platform) return next(new Error('No platform specified and impossible to detect one'));
+            if (!platform) return next(new Error('We could not detect your platform.\n\nPlease pick a download directly from: https://github.com/itchio/itch/releases\n\nThanks!'));
         } else {
             platform = null;
         }


### PR DESCRIPTION
Also fixes typo :)

Can confirm that this does wonder for [our desktop app](http://github.com/itchio/itch)

Squirrel.Windows checks the RELEASES file and happily picks the delta update that is much, much smaller than the full one.

(It still downloads it twice for some reason (presumably to get changelogs?), though, but that's okay — two times 60kb is still pretty small :shipit:)