### PR TITLE
Allow app host and base URL to be configured.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,14 @@ $ npm install
 This service requires to be configured using environment variables:
 
 ```
-# Set the port for the service
+# Set the port for the service (default is 5000)
 $ export PORT=6000
+
+# Set the host for the service (default is 0.0.0.0)
+$ export HOST=127.0.0.1
+
+# Set a base URL for the service (default is '/')
+$ export BASE_URL=/release
 
 # Access token for the GitHub API (requires permissions to access the repository)
 # If the repository is public you do not need to provide an access token

--- a/bin/web.js
+++ b/bin/web.js
@@ -4,6 +4,11 @@ var basicAuth = require('basic-auth');
 var Analytics = require('analytics-node');
 var nuts = require('../');
 
+const
+    BASE_URL = process.env.BASE_URL || '/',
+    PORT     = process.env.PORT || 5000,
+    HOST     = process.env.HOST || '0.0.0.0';
+
 var app = express();
 
 var apiAuth =  {
@@ -70,7 +75,7 @@ var myNuts = nuts({
     }
 });
 
-app.use(myNuts.router);
+app.use(BASE_URL, myNuts.router);
 
 // Error handling
 app.use(function(req, res, next) {
@@ -99,9 +104,6 @@ app.use(function(err, req, res, next) {
     });
 });
 
-var server = app.listen(process.env.PORT || 5000, function () {
-    var host = server.address().address;
-    var port = server.address().port;
-
-    console.log('Listening at http://%s:%s', host, port);
+var server = app.listen(PORT, HOST, function () {
+    console.log('Listening at http://%s:%s%s', HOST, PORT, BASE_URL);
 });


### PR DESCRIPTION
These are some small changes to allow two aspects of Nuts to be more easily configured.  They are changes that I needed to make in order to use Nuts in my situation - Nuts running on localhost with nginx proxying requests at the baseUrl to it.  I thought other people might find this kind of configurability useful too.