### PR TITLE
detect mac by "dmg" file extension

### DIFF
--- a/lib/platforms.js
+++ b/lib/platforms.js
@@ -39,7 +39,8 @@ function detectPlatform(platform) {
 
     if (_.contains(name, 'mac')
         || _.contains(name, 'osx')
-        || name.indexOf('darwin')  >= 0) prefix = platforms.OSX;
+        || name.indexOf('darwin') >= 0
+        || path.extname(name) == '.dmg') prefix = platforms.OSX;
 
     // Detect suffix: 32 or 64
     if (_.contains(name, '32')

--- a/test/platforms.js
+++ b/test/platforms.js
@@ -7,6 +7,7 @@ describe('Platforms', function() {
 
         it('should detect osx_64', function() {
             platforms.detect('myapp-v0.25.1-darwin-x64.zip').should.be.exactly(platforms.OSX_64);
+            platforms.detect('myapp.dmg').should.be.exactly(platforms.OSX_64);
         });
 
         it('should detect windows_32', function() {


### PR DESCRIPTION
First of all, thanks for great app!

We detect windows by "exe" file extension. Linux by "deb" and "rpm".
So, why not detect mac by "dmg"? It is common practice to not use special prefix "-mac" for dmg files (because DMG obviously only for OS X).

Test added, checked in production.