### PR TITLE
Detect .gz files as linux platform

### DIFF
--- a/lib/platforms.js
+++ b/lib/platforms.js
@@ -34,6 +34,7 @@ function detectPlatform(platform) {
 
     if (_.contains(name, 'linux')
         || _.contains(name, 'ubuntu')
+        || path.extname(name) == '.gz'
         || path.extname(name) == '.deb'
         || path.extname(name) == '.rpm') prefix = platforms.LINUX;
 

--- a/test/platforms.js
+++ b/test/platforms.js
@@ -17,6 +17,8 @@ describe('Platforms', function() {
         });
 
         it('should detect linux', function() {
+            platforms.detect('myapp-v0.25.1.tar.gz').should.be.exactly(platforms.LINUX_32);
+            platforms.detect('myapp-v0.25.1-amd64.tar.gz').should.be.exactly(platforms.LINUX_64);
             platforms.detect('atom-amd64.deb').should.be.exactly(platforms.LINUX_64);
         });
 


### PR DESCRIPTION
If a release download has a .gz extension, mark it as a Linux file type.