### PR TITLE
Introduce a "TRUST_PROXY" env var that sets Express's "trust proxy" setting

### DIFF
--- a/bin/web.js
+++ b/bin/web.js
@@ -77,6 +77,10 @@ myNuts.after('download', function(download, next) {
     next();
 });
 
+if (process.env.TRUST_PROXY) {
+  app.set('trust proxy', process.env.TRUST_PROXY);
+}
+
 app.use(myNuts.router);
 
 // Error handling

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -41,6 +41,11 @@ $ export GITHUB_REPO=Username/MyApp
 # Authentication for the private API
 $ export API_USERNAME=hello
 $ export API_PASSWORD=world
+
+# Express's "trust proxy" setting for trusting X-Forwarded-* headers when
+# behind a reverse proxy like nginx
+# http://expressjs.com/en/guide/behind-proxies.html
+$ export TRUST_PROXY=loopback
 ```
 
 Then start the application using:


### PR DESCRIPTION
This is for full HTTPS support when a Nuts server sits behind a reverse proxy like NGINX. Often NGINX will accept HTTPS connections and proxy them to a Node server that accepts only HTTP (in this case, the Nuts server).

However, we want the Nuts server to recognize that the client made the request over HTTPS. NGINX and other reverse proxies solve this by setting the "X-Forwarded-Proto" header to "https", which Express can access. Express has a setting called "trust proxy" that tells it to use the "X-Forwarded-*" headers as truth when receiving a connection from certain IP addresses (this is configurable; see http://expressjs.com/en/guide/behind-proxies.html).

So by exposing the "trust proxy" setting via an env var (`TRUST_PROXY`), people can run Nuts servers behind NGINX and Nuts will produce HTTPS URLs instead of HTTP ones.