### PR TITLE
Support redirecting to GitHubs artifact download URL

### DIFF
--- a/bin/web.js
+++ b/bin/web.js
@@ -24,7 +24,8 @@ var myNuts = nuts.Nuts({
     password: process.env.GITHUB_PASSWORD,
     timeout: process.env.VERSIONS_TIMEOUT,
     cache: process.env.VERSIONS_CACHE,
-    refreshSecret: process.env.GITHUB_SECRET
+    refreshSecret: process.env.GITHUB_SECRET,
+    shouldProxy: !process.env.PROXY_ASSETS
 });
 
 // Control access to API

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -44,7 +44,10 @@ function Nuts(opts) {
         preFetch: true,
 
         // Secret for GitHub webhook
-        refreshSecret: 'secret'
+        refreshSecret: 'secret',
+
+        // Proxy assets locally
+        shouldProxy: true
     });
 
     // Create router
@@ -136,6 +139,12 @@ Nuts.prototype.serveAsset = function(req, res, version, asset) {
         platform: asset
     }, function() {
         var d = Q.defer();
+
+        if (!that.opts.shouldProxy) {
+            res.redirect(asset.raw.browser_download_url);
+            return Q.resolve();
+        }
+
         res.header('Content-Length', asset.size);
         res.attachment(asset.filename);
 

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -195,7 +195,7 @@ Nuts.prototype.onDownload = function(req, res, next) {
     .fail(function(err) {
         if (channel || tag != 'latest') throw err;
 
-        return versions.resolve({
+        return that.versions.resolve({
             channel: '*',
             platform: platform,
             tag: tag


### PR DESCRIPTION
This PR adds the ability to redirect the download to Github's URL

This doesn't affect default the default behaviour but it is very useful for Open Source projects who don't want to front hosting / bandwidth costs.

Fixes #38 

/cc @SamyPesse 