### PR TITLE
Feature/targz filetype

### DIFF
--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -202,6 +202,7 @@ Nuts.prototype.onUpdateOSX = function(req, res, next) {
     var fullUrl = getFullUrl(req);
     var platform = req.params.platform;
     var tag = req.params.version;
+    var filetype = req.query.filetype ? req.query.filetype : "zip";
 
     Q()
     .then(function() {
@@ -223,7 +224,7 @@ Nuts.prototype.onUpdateOSX = function(req, res, next) {
         var releaseNotes = notes.merge(versions.slice(0, -1), { includeTag: false });
 
         res.status(200).send({
-            "url": url.resolve(fullUrl, "/download/version/"+latest.tag+"/"+platform+"?filetype=zip"),
+            "url": url.resolve(fullUrl, "/download/version/"+latest.tag+"/"+platform+"?filetype="+filetype),
             "name": latest.tag,
             "notes": releaseNotes,
             "pub_date": latest.published_at.toISOString()

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -53,8 +53,8 @@ function Nuts(opts) {
     this.router.get('/download/:tag/:filename', this.onDownload);
     this.router.get('/download/:platform?', this.onDownload);
 
-    this.router.get('/update', this.onUpdate);
-    this.router.get('/update/:platform/:version', this.onUpdateOSX);
+    this.router.get('/update', this.onUpdateRedirect);
+    this.router.get('/update/:platform/:version', this.onUpdate);
     this.router.get('/update/:platform/:version/RELEASES', this.onUpdateWin);
 
     this.router.get('/notes/:version?', this.onServeNotes);
@@ -185,7 +185,7 @@ Nuts.prototype.onDownload = function(req, res, next) {
 
 
 // Request to update
-Nuts.prototype.onUpdate = function(req, res, next) {
+Nuts.prototype.onUpdateRedirect = function(req, res, next) {
     Q()
     .then(function() {
         if (!req.query.version) throw new Error('Requires "version" parameter');
@@ -196,8 +196,8 @@ Nuts.prototype.onUpdate = function(req, res, next) {
     .fail(next);
 };
 
-// Updater OSX (Squirrel.Mac)
-Nuts.prototype.onUpdateOSX = function(req, res, next) {
+// Updater used by OSX (Squirrel.Mac) and others
+Nuts.prototype.onUpdate = function(req, res, next) {
     var that = this;
     var fullUrl = getFullUrl(req);
     var platform = req.params.platform;

--- a/lib/utils/platforms.js
+++ b/lib/utils/platforms.js
@@ -26,23 +26,23 @@ function detectPlatform(platform) {
     var prefix = "", suffix = "";
 
     // Detect NuGet/Squirrel.Windows files
-    if (name == 'releases' || path.extname(name) == '.nupkg') return platforms.WINDOWS_32;
+    if (name == 'releases' || hasSuffix(name, '.nupkg')) return platforms.WINDOWS_32;
 
     // Detect prefix: osx, widnows or linux
     if (_.contains(name, 'win')
-        || path.extname(name) == '.exe') prefix = platforms.WINDOWS;
+        || hasSuffix(name, '.exe')) prefix = platforms.WINDOWS;
 
     if (_.contains(name, 'linux')
         || _.contains(name, 'ubuntu')
-        || path.extname(name) == '.deb'
-        || path.extname(name) == '.rpm'
-        || path.extname(name) == '.tgz'
-        || path.extname(name) == '.tar.gz') prefix = platforms.LINUX;
+        || hasSuffix(name, '.deb')
+        || hasSuffix(name, '.rpm')
+        || hasSuffix(name, '.tgz')
+        || hasSuffix(name, '.tar.gz')) prefix = platforms.LINUX;
 
     if (_.contains(name, 'mac')
         || _.contains(name, 'osx')
         || name.indexOf('darwin') >= 0
-        || path.extname(name) == '.dmg') prefix = platforms.OSX;
+        || hasSuffix(name, '.dmg')) prefix = platforms.OSX;
 
     // Detect suffix: 32 or 64
     if (_.contains(name, '32')
@@ -52,6 +52,10 @@ function detectPlatform(platform) {
 
     suffix = suffix || (prefix == platforms.OSX? '64' : '32');
     return _.compact([prefix, suffix]).join('_');
+}
+
+function hasSuffix(str, suffix) {
+    return str.slice(str.length-suffix.length) === suffix;
 }
 
 // Satisfies a platform

--- a/lib/utils/platforms.js
+++ b/lib/utils/platforms.js
@@ -35,7 +35,9 @@ function detectPlatform(platform) {
     if (_.contains(name, 'linux')
         || _.contains(name, 'ubuntu')
         || path.extname(name) == '.deb'
-        || path.extname(name) == '.rpm') prefix = platforms.LINUX;
+        || path.extname(name) == '.rpm'
+        || path.extname(name) == '.tgz'
+        || path.extname(name) == '.tar.gz') prefix = platforms.LINUX;
 
     if (_.contains(name, 'mac')
         || _.contains(name, 'osx')
@@ -66,7 +68,7 @@ function satisfiesPlatform(platform, list) {
 function resolveForVersion(version, platformID, opts) {
     opts = _.defaults(opts || {}, {
         // Order for filetype
-        filePreference: ['.exe', '.dmg', '.deb', '.rpm', '.zip', '.nupkg'],
+        filePreference: ['.exe', '.dmg', '.deb', '.rpm', '.tgz', '.tar.gz', '.zip', '.nupkg'],
         wanted: null
     });
 

--- a/test/platforms.js
+++ b/test/platforms.js
@@ -18,6 +18,8 @@ describe('Platforms', function() {
 
         it('should detect linux', function() {
             platforms.detect('atom-amd64.deb').should.be.exactly(platforms.LINUX_64);
+            platforms.detect('enterprise-amd64.tar.gz').should.be.exactly(platforms.LINUX_64);
+            platforms.detect('enterprise-amd64.tgz').should.be.exactly(platforms.LINUX_64);
         });
 
     });


### PR DESCRIPTION
- [x] On download support passing a custom `?filetype=...` querystring arg, default to `zip`
- [x] Match `.tar.gz` and `.tgz` extensions to `LINUX`