### PR TITLE
Feature/autoinit

### DIFF
--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -37,6 +37,9 @@ function Nuts(opts) {
         refreshSecret: 'secret'
     });
 
+    // Init promise (keep our init promise so we only call it once)
+    this._initPromise = null;
+
     // Create router
     this.router = express.Router();
 
@@ -75,9 +78,28 @@ function Nuts(opts) {
 }
 
 // Prepare nuts
+// init really caches a call to ._init()
+// so subsequent calls return immediately
 Nuts.prototype.init = function() {
     var that = this;
 
+    // Already inited
+    if(this._initPromise !== null) {
+        return this._initPromise;
+    }
+
+    // Real init promise chain
+    var promise = this._init();
+
+    // Cache promise
+    this._initPromise = promise;
+
+    return this._initPromise;
+};
+
+// _init does the real init work, initializing backend and prefetching versions
+Nuts.prototype._init = function() {
+    var that = this;
     return Q()
     .then(function() {
         return that.backend.init();
@@ -86,7 +108,8 @@ Nuts.prototype.init = function() {
         if (!that.opts.preFetch) return
         return that.versions.list();
     });
-};
+}
+
 
 // Perform a hook using promised functions
 Nuts.prototype.performQ = function(name, arg, fn) {

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -131,12 +131,15 @@ Nuts.prototype.performQ = function(name, arg, fn) {
 Nuts.prototype.serveAsset = function(req, res, version, asset) {
     var that = this;
 
-    return this.performQ('download', {
-        req: req,
-        version: version,
-        platform: asset
-    }, function() {
-        return that.backend.serveAsset(asset, req, res)
+    return that.init()
+    .then(function() {
+        return that.performQ('download', {
+            req: req,
+            version: version,
+            platform: asset
+        }, function() {
+            return that.backend.serveAsset(asset, req, res)
+        });
     });
 };
 
@@ -266,7 +269,7 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
     var platform = 'win_32';
     var tag = req.params.version;
 
-    Q()
+    that.init()
     .then(function() {
         platform = platforms.detect(platform);
 

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -37,8 +37,8 @@ function Nuts(opts) {
         refreshSecret: 'secret'
     });
 
-    // Init promise (keep our init promise so we only call it once)
-    this._initPromise = null;
+    // .init() is now a memoized version of ._init()
+    this.init = _.memoize(this._init);
 
     // Create router
     this.router = express.Router();
@@ -76,26 +76,6 @@ function Nuts(opts) {
         });
     }, this);
 }
-
-// Prepare nuts
-// init really caches a call to ._init()
-// so subsequent calls return immediately
-Nuts.prototype.init = function() {
-    var that = this;
-
-    // Already inited
-    if(this._initPromise !== null) {
-        return this._initPromise;
-    }
-
-    // Real init promise chain
-    var promise = this._init();
-
-    // Cache promise
-    this._initPromise = promise;
-
-    return this._initPromise;
-};
 
 // _init does the real init work, initializing backend and prefetching versions
 Nuts.prototype._init = function() {


### PR DESCRIPTION
Makes calling `Nuts.init()` optional since it's now called when needed inside `Nuts`

Fixes #41 