### PR TITLE
Strip channel when calling semver.satisfies to allow custom channels

### DIFF
--- a/lib/versions.js
+++ b/lib/versions.js
@@ -10,6 +10,10 @@ function normalizeTag(tag) {
     return tag;
 }
 
+function stripChannel(tag) {
+    return tag.replace(/-.*$/, '');
+}
+
 // Extract channel of version
 function extractChannel(tag) {
     var suffix = tag.split('-')[1];
@@ -106,7 +110,7 @@ Versions.prototype.filter = function(opts) {
                 if (opts.platform && !platforms.satisfies(opts.platform, _.pluck(version.platforms, 'type'))) return false;
 
                 // Check tag satisfies request version
-                return opts.tag == 'latest' || semver.satisfies(version.tag, opts.tag);
+                return opts.tag == 'latest' || semver.satisfies(stripChannel(version.tag), stripChannel(opts.tag));
             })
             .value();
     });


### PR DESCRIPTION
The `semver` packages doesn't seem to have any problems dealing with custom channels when calling `gt`:

```
> semver.gt('v0.14.1-canary', 'v0.14.0-canary')
true
```

But `satisfies` doesn't seem to like it:

```
> semver.satisfies('v0.14.1-canary', '>=v0.14.0-canary')
false
```

As a result, nuts always returns HTTP 204 for URLs like:

```
curl "http://nuts-canary.itch.ovh/update/darwin_x64/0.14.0-canary"
```

This patch strips the channel before calling `semver.satisfies`, which fixes the issue for us.