### PR TITLE
[Auth] Add an option to connect to GitHub anonymously for public repos

### DIFF
--- a/bin/web.js
+++ b/bin/web.js
@@ -1,4 +1,5 @@
 var express = require('express');
+var getenv = require('getenv');
 var uuid = require('uuid');
 var basicAuth = require('basic-auth');
 var Analytics = require('analytics-node');
@@ -19,13 +20,14 @@ if (process.env.ANALYTICS_TOKEN) {
 
 var myNuts = nuts.Nuts({
     repository: process.env.GITHUB_REPO,
+    anonymous: getenv.boolish('GITHUB_ANONYMOUS', false),
     token: process.env.GITHUB_TOKEN,
     username: process.env.GITHUB_USERNAME,
     password: process.env.GITHUB_PASSWORD,
     timeout: process.env.VERSIONS_TIMEOUT,
     cache: process.env.VERSIONS_CACHE,
     refreshSecret: process.env.GITHUB_SECRET,
-    proxyAssets: !Boolean(process.env.DONT_PROXY_ASSETS)
+    proxyAssets: !getenv.boolish('DONT_PROXY_ASSETS', false)
 });
 
 // Control access to API

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -31,9 +31,11 @@ This service requires to be configured using environment variables:
 $ export PORT=6000
 
 # Access token for the GitHub API (requires permissions to access the repository)
-# If the repository is public you do not need to provide an access token
 # you can also use GITHUB_USERNAME and GITHUB_PASSWORD
 $ export GITHUB_TOKEN=...
+
+# Or, if the repository is public you do not need to provide an access token
+$ export GITHUB_ANONYMOUS=1
 
 # ID for the GitHub repository
 $ export GITHUB_REPO=Username/MyApp

--- a/lib/backends/github.js
+++ b/lib/backends/github.js
@@ -17,8 +17,8 @@ function GitHubBackend() {
         proxyAssets: true
     });
 
-    if ((!this.opts.username || !this.opts.password) && (!this.opts.token)) {
-        throw new Error('GitHub backend require "username" and "token" options');
+    if ((!this.opts.username || !this.opts.password) && (!this.opts.token) && (!this.opts.anonymous)) {
+        throw new Error('GitHub backend requires either the "username" and "password, "token", or "anonymous" option');
     }
 
     this.client = new GitHub({

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "express": "^4.13.3",
     "express-useragent": "0.1.9",
     "feed": "^0.3.0",
+    "getenv": "^0.6.0",
     "github-webhook-handler": "0.5.0",
     "lodash": "3.7.0",
     "lru-diskcache": "1.1.1",


### PR DESCRIPTION
Adds a new option called `GITHUB_ANONYMOUS` to signal that you want to public repositories that don't require any authentication. If you don't set this to true, Nuts will continue to throw an error if you don't provide authentication credentials.

This uses the `getenv` package, which handles env var values like "true" and "1" as bash would.
