### PR TITLE
Expose manual refresh endpoint

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -18,6 +18,15 @@ module.exports = {
         return this.versions.channels();
     },
 
+    'refresh': function () {
+        this.backend.onRelease();
+        this.versions.list();
+
+        return {
+            refresh: "done"
+        }
+    },
+
     'version/:tag': function (req) {
         return this.versions.resolve({
             tag: req.params.tag,

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,4 +1,5 @@
 var startTime = Date.now();
+var Q = require('q');
 
 module.exports = {
     'status': function () {
@@ -19,12 +20,10 @@ module.exports = {
     },
 
     'refresh': function () {
-        this.backend.onRelease();
-        this.versions.list();
-
-        return {
-            refresh: "done"
-        }
+        return Q()
+            .then(this.backend.onRelease)
+            .thenResolve({done: true}
+        );
     },
 
     'version/:tag': function (req) {


### PR DESCRIPTION
Sometimes it's useful to trigger a manual refresh of the cache, for example after changing the description of a Github release.