### PR TITLE
Allow TRUST_PROXY to pass JSON arguments to Express

### DIFF
--- a/bin/web.js
+++ b/bin/web.js
@@ -78,7 +78,13 @@ myNuts.after('download', function(download, next) {
 });
 
 if (process.env.TRUST_PROXY) {
-  app.set('trust proxy', process.env.TRUST_PROXY);
+    try {
+        var trustProxyObject = JSON.parse(process.env.TRUST_PROXY);
+        app.set('trust proxy', trustProxyObject);
+    }
+    catch (e) {
+        app.set('trust proxy', process.env.TRUST_PROXY);
+    }
 }
 
 app.use(myNuts.router);


### PR DESCRIPTION
Parse the TRUST_PROXY value as JSON

 

- Allow the express API to use the:
    Boolean, Array, and Number argument types

- Fallback to passing the raw string into express API

-  Handles SyntaxException from JSON.parse