### PR TITLE
remove versions.list() from github backend

### DIFF
--- a/lib/backends/github.js
+++ b/lib/backends/github.js
@@ -39,7 +39,6 @@ function GitHubBackend() {
     // Webhook from GitHub
     this.webhookHandler.on('release', function(event) {
         that.onRelease();
-        that.versions.list();
     });
     this.nuts.router.use(this.webhookHandler);
 }


### PR DESCRIPTION
Fix for #59. The `versions` variable was removed in a0fa9aa, so this line causes a crash whenever the github webhook is triggered.