### PR TITLE
Add missing context reference

### DIFF
--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -163,7 +163,7 @@ Nuts.prototype.onDownload = function(req, res, next) {
     .fail(function(err) {
         if (channel || tag != 'latest') throw err;
 
-        return versions.resolve({
+        return that.versions.resolve({
             channel: '*',
             platform: platform,
             tag: tag


### PR DESCRIPTION
I believe you dropped a 'that'. Without it, I get the following error. After adding it, I was able to successfully download an edge version from my nuts server.

```javascript
web-0 (err): ReferenceError: versions is not defined
web-0 (err):     at /home/ec2-user/nuts/lib/nuts.js:166:16
web-0 (err):     at _rejected (/home/ec2-user/nuts/node_modules/octocat/node_modules/q/q.js:844:24)
web-0 (err):     at /home/ec2-user/nuts/node_modules/octocat/node_modules/q/q.js:870:30
web-0 (err):     at Promise.when (/home/ec2-user/nuts/node_modules/octocat/node_modules/q/q.js:1122:31)
web-0 (err):     at Promise.promise.promiseDispatch (/home/ec2-user/nuts/node_modules/octocat/node_modules/q/q.js:788:41)
web-0 (err):     at /home/ec2-user/nuts/node_modules/octocat/node_modules/q/q.js:604:44
web-0 (err):     at runSingle (/home/ec2-user/nuts/node_modules/octocat/node_modules/q/q.js:137:13)
web-0 (err):     at flush (/home/ec2-user/nuts/node_modules/octocat/node_modules/q/q.js:125:13)
web-0 (err):     at nextTickCallbackWith0Args (node.js:420:9)
web-0 (err):     at process._tickDomainCallback (node.js:390:13)
```