### PR TITLE
fixes issue with a single release

### DIFF
--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -230,7 +230,11 @@ Nuts.prototype.onUpdate = function(req, res, next) {
         var latest = _.first(versions);
         if (!latest || latest.tag == tag) return res.status(204).send('No updates');
 
-        var releaseNotes = notes.merge(versions.slice(0, -1), { includeTag: false });
+        var notesSlice = versions.slice(0, -1);
+        if (versions.length === 1) {
+            notesSlice = [versions[0]];
+        }
+        var releaseNotes = notes.merge(notesSlice, { includeTag: false });
 
         res.status(200).send({
             "url": urljoin(fullUrl, '/../../../', '/download/version/'+latest.tag+'/'+platform+'?filetype='+filetype),


### PR DESCRIPTION
resolves #71.

If there was a single release calling array.slice(0,-1) returns an empty array.  I added some logic to detect if it was a single release to account for it.