### PR TITLE
[SECURITY] Update application to support https endpoints

### DIFF
--- a/bin/web.js
+++ b/bin/web.js
@@ -3,6 +3,16 @@ var uuid = require('uuid');
 var basicAuth = require('basic-auth');
 var Analytics = require('analytics-node');
 var nuts = require('../');
+var fs = require('fs');
+var https = require('https');
+
+var key = fs.readFileSync(process.env.HTTPS_KEYFILE);
+var cert = fs.readFileSync(process.env.HTTPS_CERTFILE);
+
+var https_options = {
+   key: key,
+   cert: cert
+};
 
 var app = express();
 
@@ -118,8 +128,19 @@ app.use(function(err, req, res, next) {
 
 myNuts.init()
 
-// Start the HTTP server
+// Start the HTTP and/or HTTPS server
 .then(function() {
+
+    // Enable https endpoint if key and cert are set
+    if(key != "" && cert != "") {
+        var https_server = https.createServer(https_options, app).listen(process.env.HTTPSPORT || 5001, function () {
+            var hosts = https_server.address().address;
+            var ports = https_server.address().port;
+
+            console.log('Listening at https://%s:%s', hosts, ports);
+        });
+    }
+
     var server = app.listen(process.env.PORT || 5000, function () {
         var host = server.address().address;
         var port = server.address().port;

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -27,8 +27,13 @@ $ npm install
 This service requires to be configured using environment variables:
 
 ```
-# Set the port for the service
+# Set the port for the http service
 $ export PORT=6000
+
+# Set the port for the https service (optional)
+$ export HTTPSPORT=6001
+$ export HTTPS_KEYFILE=<Full Path to Private Key File>
+$ export HTTPS_CERTFILE=<Full Path to Public Certificate File>
 
 # Access token for the GitHub API (requires permissions to access the repository)
 # If the repository is public you do not need to provide an access token


### PR DESCRIPTION
This is a critical security fix for potential MITM attacks against http endpoints. An attacker could hijack the nuts server responses and force users to download vulnerable software unknowingly. This pull request enables an optional (but recommended) https endpoint so that applications will be protected when retrieving updates.