### PR TITLE
updated linux support

### DIFF
--- a/lib/utils/platforms.js
+++ b/lib/utils/platforms.js
@@ -5,6 +5,12 @@ var platforms = {
     LINUX: 'linux',
     LINUX_32: 'linux_32',
     LINUX_64: 'linux_64',
+    LINUX_RPM: 'linux_rpm',
+    LINUX_RPM_32: 'linux_rpm_32',
+    LINUX_RPM_64: 'linux_rpm_64',
+    LINUX_DEB: 'linux_deb',
+    LINUX_DEB_32: 'linux_deb_32',
+    LINUX_DEB_64: 'linux_deb_64',
     OSX: 'osx',
     OSX_32: 'osx_32',
     OSX_64: 'osx_64',
@@ -37,7 +43,18 @@ function detectPlatform(platform) {
         || hasSuffix(name, '.deb')
         || hasSuffix(name, '.rpm')
         || hasSuffix(name, '.tgz')
-        || hasSuffix(name, '.tar.gz')) prefix = platforms.LINUX;
+        || hasSuffix(name, '.tar.gz')) {
+
+        if (_.contains(name, 'linux_deb') || hasSuffix(name, '.deb')) {
+            prefix = platforms.LINUX_DEB;
+        }
+        else if (_.contains(name, 'linux_rpm') || hasSuffix(name, '.rpm')) {
+            prefix = platforms.LINUX_RPM;
+        }
+        else if (_.contains(name, 'linux') || hasSuffix(name, '.tgz') || hasSuffix(name, '.tar.gz')) {
+            prefix = platforms.LINUX;
+        }
+    }
 
     if (_.contains(name, 'mac')
         || _.contains(name, 'osx')

--- a/test/platforms.js
+++ b/test/platforms.js
@@ -17,9 +17,26 @@ describe('Platforms', function() {
         });
 
         it('should detect linux', function() {
-            platforms.detect('atom-amd64.deb').should.be.exactly(platforms.LINUX_64);
             platforms.detect('enterprise-amd64.tar.gz').should.be.exactly(platforms.LINUX_64);
             platforms.detect('enterprise-amd64.tgz').should.be.exactly(platforms.LINUX_64);
+            platforms.detect('enterprise-ia32.tar.gz').should.be.exactly(platforms.LINUX_32);
+            platforms.detect('enterprise-ia32.tgz').should.be.exactly(platforms.LINUX_32);
+        });
+
+        it('should detect debian_32', function() {
+            platforms.detect('atom-ia32.deb').should.be.exactly(platforms.LINUX_DEB_32);
+        });
+
+        it('should detect debian_64', function() {
+            platforms.detect('atom-amd64.deb').should.be.exactly(platforms.LINUX_DEB_64);
+        });
+
+        it('should detect rpm_32', function() {
+            platforms.detect('atom-ia32.rpm').should.be.exactly(platforms.LINUX_RPM_32);
+        });
+
+        it('should detect rpm_64', function() {
+            platforms.detect('atom-amd64.rpm').should.be.exactly(platforms.LINUX_RPM_64);
         });
 
     });
@@ -56,7 +73,47 @@ describe('Platforms', function() {
                     "download_count": 26987
                 },
                 {
+                    "type": "linux_32",
+                    "filename": "atom-ia32.tar.gz",
+                    "size": 71292506,
+                    "content_type": "application/zip",
+                    "download_url": "https://api.github.com/repos/atom/atom/releases/assets/825658",
+                    "download_count": 2494
+                },
+                {
                     "type": "linux_64",
+                    "filename": "atom-amd64.tar.gz",
+                    "size": 71292506,
+                    "content_type": "application/zip",
+                    "download_url": "https://api.github.com/repos/atom/atom/releases/assets/825658",
+                    "download_count": 2494
+                },
+                {
+                    "type": "linux_rpm_32",
+                    "filename": "atom-ia32.rpm",
+                    "size": 71292506,
+                    "content_type": "application/zip",
+                    "download_url": "https://api.github.com/repos/atom/atom/releases/assets/825658",
+                    "download_count": 2494
+                },
+                {
+                    "type": "linux_rpm_64",
+                    "filename": "atom-amd64.rpm",
+                    "size": 71292506,
+                    "content_type": "application/zip",
+                    "download_url": "https://api.github.com/repos/atom/atom/releases/assets/825658",
+                    "download_count": 2494
+                },
+                {
+                    "type": "linux_deb_32",
+                    "filename": "atom-ia32.deb",
+                    "size": 71292506,
+                    "content_type": "application/zip",
+                    "download_url": "https://api.github.com/repos/atom/atom/releases/assets/825658",
+                    "download_count": 2494
+                },
+                {
+                    "type": "linux_deb_64",
                     "filename": "atom-amd64.deb",
                     "size": 71292506,
                     "content_type": "application/zip",
@@ -84,8 +141,14 @@ describe('Platforms', function() {
 
 
         it('should resolve to best platform', function() {
-            platforms.resolve(version, 'osx').filename.should.be.exactly("test-3.3.1-darwin.dmg"),
-            platforms.resolve(version, 'win32').filename.should.be.exactly("AtomSetup.exe")
+            platforms.resolve(version, 'osx').filename.should.be.exactly("test-3.3.1-darwin.dmg");
+            platforms.resolve(version, 'win32').filename.should.be.exactly("AtomSetup.exe");
+            platforms.resolve(version, 'linux_64').filename.should.be.exactly("atom-amd64.tar.gz");
+            platforms.resolve(version, 'linux_32').filename.should.be.exactly("atom-ia32.tar.gz");
+            platforms.resolve(version, 'linux_rpm_32').filename.should.be.exactly("atom-ia32.rpm");
+            platforms.resolve(version, 'linux_rpm_64').filename.should.be.exactly("atom-amd64.rpm");
+            platforms.resolve(version, 'linux_deb_32').filename.should.be.exactly("atom-ia32.deb");
+            platforms.resolve(version, 'linux_deb_64').filename.should.be.exactly("atom-amd64.deb");
         });
 
         it('should resolve to best platform with a preferred filetype', function() {


### PR DESCRIPTION
added support for downloading deb files for debian/ubuntu and rpm files for rhel/fedora/centos.

resolves #83 