### PR TITLE
Better unit tests

### DIFF
--- a/bin/web.js
+++ b/bin/web.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 var express = require('express');
 var uuid = require('uuid');
 var basicAuth = require('basic-auth');
@@ -18,15 +20,15 @@ if (process.env.ANALYTICS_TOKEN) {
 }
 
 var myNuts = nuts.Nuts({
-    repository: process.env.GITHUB_REPO,
-    token: process.env.GITHUB_TOKEN,
-    endpoint: process.env.GITHUB_ENDPOINT,
-    username: process.env.GITHUB_USERNAME,
-    password: process.env.GITHUB_PASSWORD,
-    timeout: process.env.VERSIONS_TIMEOUT,
-    cache: process.env.VERSIONS_CACHE,
+    repository:    process.env.GITHUB_REPO,
+    token:         process.env.GITHUB_TOKEN,
+    endpoint:      process.env.GITHUB_ENDPOINT,
+    username:      process.env.GITHUB_USERNAME,
+    password:      process.env.GITHUB_PASSWORD,
+    timeout:       process.env.VERSIONS_TIMEOUT,
+    cache:         process.env.VERSIONS_CACHE,
     refreshSecret: process.env.GITHUB_SECRET,
-    proxyAssets: !Boolean(process.env.DONT_PROXY_ASSETS)
+    proxyAssets:   !process.env.DONT_PROXY_ASSETS
 });
 
 // Control access to API
@@ -35,28 +37,28 @@ myNuts.before('api', function(access, next) {
 
     function unauthorized() {
         next(new Error('Invalid username/password for API'));
-    };
+    }
 
     var user = basicAuth(access.req);
     if (!user || !user.name || !user.pass) {
         return unauthorized();
-    };
+    }
 
     if (user.name === apiAuth.username && user.pass === apiAuth.password) {
         return next();
     } else {
         return unauthorized();
-    };
+    }
 });
 
 // Log download
 myNuts.before('download', function(download, next) {
-    console.log('download', download.platform.filename, "for version", download.version.tag, "on channel", download.version.channel, "for", download.platform.type);
+    console.log('download', download.platform.filename, 'for version', download.version.tag, 'on channel', download.version.channel, 'for', download.platform.type);
 
     next();
 });
 myNuts.after('download', function(download, next) {
-    console.log('downloaded', download.platform.filename, "for version", download.version.tag, "on channel", download.version.channel, "for", download.platform.type);
+    console.log('downloaded', download.platform.filename, 'for version', download.version.tag, 'on channel', download.version.channel, 'for', download.platform.type);
 
     // Track on segment if enabled
     if (analytics) {
@@ -92,7 +94,7 @@ app.use(myNuts.router);
 
 // Error handling
 app.use(function(req, res, next) {
-    res.status(404).send("Page not found");
+    res.status(404).send('Page not found');
 });
 app.use(function(err, req, res, next) {
     var msg = err.message || err;

--- a/lib/backends/github.js
+++ b/lib/backends/github.js
@@ -1,13 +1,12 @@
 var _ = require('lodash');
 var Q = require('q');
 var util = require('util');
-var destroy = require('destroy');
 var GitHub = require('octocat');
 var request = require('request');
-var Buffer = require('buffer').Buffer;
 var githubWebhook = require('github-webhook-handler');
 
 var Backend = require('./backend');
+
 
 function GitHubBackend() {
     var that = this;
@@ -17,19 +16,15 @@ function GitHubBackend() {
         proxyAssets: true
     });
 
-    if ((!this.opts.username || !this.opts.password) && (!this.opts.token)) {
-        throw new Error('GitHub backend require "username" and "token" options');
-    }
-
     this.client = new GitHub({
-        token: this.opts.token,
+        token:    this.opts.token,
         endpoint: this.opts.endpoint,
         username: this.opts.username,
         password: this.opts.password
     });
 
     this.ghrepo = this.client.repo(this.opts.repository);
-    this.releases = this.memoize(this._releases);
+    this.releases = this.memoize(this.releases);
 
     // GitHub webhook to refresh list of versions
     this.webhookHandler = githubWebhook({
@@ -45,15 +40,24 @@ function GitHubBackend() {
 }
 util.inherits(GitHubBackend, Backend);
 
-// List all releases for this repository
-GitHubBackend.prototype._releases = function() {
+/**
+ * List all releases for this repository
+ * @return {Promise<Array<Release>>}
+ */
+GitHubBackend.prototype.releases = function() {
     return this.ghrepo.releases()
     .then(function(page) {
         return page.all();
     });
 };
 
-// Return stream for an asset
+/**
+ * Return stream for an asset
+ * @param {Asset} asset
+ * @param {Request} req
+ * @param {Response} res
+ * @return {Promise}?
+ */
 GitHubBackend.prototype.serveAsset = function(asset, req, res) {
     if (!this.opts.proxyAssets) {
         res.redirect(asset.raw.browser_download_url);
@@ -62,7 +66,11 @@ GitHubBackend.prototype.serveAsset = function(asset, req, res) {
     }
 };
 
-// Return stream for an asset
+/**
+ * Return stream for an asset
+ * @param {Asset} asset
+ * @return {Promise<Stream>}
+ */
 GitHubBackend.prototype.getAssetStream = function(asset) {
     var headers = {
         'User-Agent': 'nuts',
@@ -87,6 +95,5 @@ GitHubBackend.prototype.getAssetStream = function(asset) {
         auth: httpAuth
     }));
 };
-
 
 module.exports = GitHubBackend;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,35 @@
+var express = require('express');
+
 var Nuts = require('./nuts');
 var platforms = require('./utils/platforms');
 var winReleases = require('./utils/win-releases');
 
+/**
+ * Create an express application with Nuts binded to it.
+ * This is mostly used for unit testing.
+ *
+ * @param {Object} options
+ * @return {Express.Application} app
+ */
+function createApp(options) {
+    var app = express();
+    var nuts = Nuts(options);
+
+    app.use(nuts.router);
+
+    app.use(function(err, req, res, next) {
+        res.status(err.statusCode || 500);
+        res.send({
+            message: err.message
+        });
+    });
+
+    return app;
+}
+
 module.exports = {
-    Nuts: Nuts,
-    platforms: platforms,
-    winReleases: winReleases
+    Nuts:        Nuts,
+    platforms:   platforms,
+    winReleases: winReleases,
+    createApp:   createApp
 };

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -242,8 +242,8 @@ Nuts.prototype.onUpdate = function(req, res, next) {
 
     Q()
     .then(function() {
-        if (!tag) throw new Error('Requires "version" parameter');
-        if (!platform) throw new Error('Requires "platform" parameter');
+        if (!tag) throw createError(400, 'Requires "version" parameter');
+        if (!platform) throw createError(400, 'Requires "platform" parameter');
 
         platform = platforms.detect(platform);
 
@@ -255,7 +255,9 @@ Nuts.prototype.onUpdate = function(req, res, next) {
     })
     .then(function(versions) {
         var latest = _.first(versions);
-        if (!latest || latest.tag == tag) return res.status(204).send('No updates');
+        if (!latest || latest.tag == tag) {
+            return res.status(204).send('No updates');
+        }
 
         var notesSlice = versions.slice(0, -1);
         if (versions.length === 1) {

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -7,11 +7,11 @@ var express = require('express');
 var useragent = require('express-useragent');
 var createError = require('http-errors');
 
-var BACKENDS = require('./backends');
 var Versions = require('./versions');
 var notes = require('./utils/notes');
 var platforms = require('./utils/platforms');
 var winReleases = require('./utils/win-releases');
+var BACKENDS = require('./backends');
 var API_METHODS = require('./api');
 
 function getFullUrl(req) {

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -5,6 +5,7 @@ var urljoin = require('urljoin.js');
 var Understudy = require('understudy');
 var express = require('express');
 var useragent = require('express-useragent');
+var createError = require('http-errors');
 
 var BACKENDS = require('./backends');
 var Versions = require('./versions');
@@ -90,13 +91,22 @@ Nuts.prototype._init = function() {
         return that.backend.init();
     })
     .then(function() {
-        if (!that.opts.preFetch) return
+        if (!that.opts.preFetch) {
+            return;
+        }
+
         return that.versions.list();
     });
-}
+};
 
 
-// Perform a hook using promised functions
+/**
+ * Perform a hook using promised functions
+ * @param  {String} name
+ * @param  {Object} arg
+ * @param  {Function} fn
+ * @return {Promise<Object>}
+ */
 Nuts.prototype.performQ = function(name, arg, fn) {
     var that = this;
     fn = fn || function() { };
@@ -109,10 +119,17 @@ Nuts.prototype.performQ = function(name, arg, fn) {
         .then(function() {
             next();
         }, next);
-    })
+    });
 };
 
-// Serve an asset to the response
+/**
+ * Serve an asset to the response
+ * @param {Request} req
+ * @param {Response} res
+ * @param {Version} version
+ * @param {String} asset
+ * @return {Promise}
+ */
 Nuts.prototype.serveAsset = function(req, res, version, asset) {
     var that = this;
 
@@ -123,18 +140,18 @@ Nuts.prototype.serveAsset = function(req, res, version, asset) {
             version: version,
             platform: asset
         }, function() {
-            return that.backend.serveAsset(asset, req, res)
+            return that.backend.serveAsset(asset, req, res);
         });
     });
 };
 
 // Handler for download routes
 Nuts.prototype.onDownload = function(req, res, next) {
-    var that = this;
-    var channel = req.params.channel;
-    var platform = req.params.platform;
-    var tag = req.params.tag || 'latest';
-    var filename = req.params.filename;
+    var that           = this;
+    var channel        = req.params.channel;
+    var platform       = req.params.platform;
+    var tag            = req.params.tag || 'latest';
+    var filename       = req.params.filename;
     var filetypeWanted = req.query.filetype;
 
     // When serving a specific file, platform is not required
@@ -147,13 +164,17 @@ Nuts.prototype.onDownload = function(req, res, next) {
             if (req.useragent.isLinux64) platform = platforms.LINUX_64;
         }
 
-        if (!platform) return next(new Error('No platform specified and impossible to detect one'));
+        if (!platform) {
+            return next(createError(400, 'No platform specified and impossible to detect one'));
+        }
     } else {
         platform = null;
     }
 
     // If specific version, don't enforce a channel
-    if (tag != 'latest') channel = '*';
+    if (tag != 'latest') {
+        channel = '*';
+    }
 
     this.versions.resolve({
         channel: channel,
@@ -186,7 +207,10 @@ Nuts.prototype.onDownload = function(req, res, next) {
             });
         }
 
-        if (!asset) throw new Error("No download available for platform "+platform+" for version "+version.tag+" ("+(channel || "beta")+")");
+        if (!asset) {
+            throw createError(404, 'No download available for platform ' + platform
+                + ' for version ' + version.tag + ' (' + (channel || 'beta') + ')');
+        }
 
         // Call analytic middleware, then serve
         return that.serveAsset(req, res, version, asset);
@@ -214,7 +238,7 @@ Nuts.prototype.onUpdate = function(req, res, next) {
     var platform = req.params.platform;
     var channel = req.params.channel || '*';
     var tag = req.params.version;
-    var filetype = req.query.filetype ? req.query.filetype : "zip";
+    var filetype = req.query.filetype ? req.query.filetype : 'zip';
 
     Q()
     .then(function() {
@@ -238,13 +262,12 @@ Nuts.prototype.onUpdate = function(req, res, next) {
             notesSlice = [versions[0]];
         }
         var releaseNotes = notes.merge(notesSlice, { includeTag: false });
-        console.error(latest.tag);
         var gitFilePath = (channel === '*' ? '/../../../' : '/../../../../../');
         res.status(200).send({
-            "url": urljoin(fullUrl, gitFilePath, '/download/version/'+latest.tag+'/'+platform+'?filetype='+filetype),
-            "name": latest.tag,
-            "notes": releaseNotes,
-            "pub_date": latest.published_at.toISOString()
+            'url': urljoin(fullUrl, gitFilePath, '/download/version/'+latest.tag+'/'+platform+'?filetype='+filetype),
+            'name': latest.tag,
+            'notes': releaseNotes,
+            'pub_date': latest.published_at.toISOString()
         });
     })
     .fail(next);
@@ -274,16 +297,16 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
     .then(function(versions) {
         // Update needed?
         var latest = _.first(versions);
-        if (!latest) throw new Error("Version not found");
+        if (!latest) throw new Error('Version not found');
 
         // File exists
         var asset = _.find(latest.platforms, {
             filename: 'RELEASES'
         });
-        if (!asset) throw new Error("File not found");
+        if (!asset) throw new Error('File not found');
 
-       return that.backend.readAsset(asset)
-       .then(function(content) {
+        return that.backend.readAsset(asset)
+        .then(function(content) {
             var releases = winReleases.parse(content.toString('utf-8'));
 
             releases = _.chain(releases)
@@ -301,9 +324,9 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
             var output = winReleases.generate(releases);
 
             res.header('Content-Length', output.length);
-            res.attachment("RELEASES");
+            res.attachment('RELEASES');
             res.send(output);
-       });
+        });
     })
     .fail(next);
 };
@@ -322,21 +345,19 @@ Nuts.prototype.onServeNotes = function(req, res, next) {
     })
     .then(function(versions) {
         var latest = _.first(versions);
-
-        if (!latest) throw new Error('No versions matching');
+        if (!latest) {
+            throw new Error('No versions matching');
+        }
 
         res.format({
-            'text/plain': function(){
-                res.send(notes.merge(versions));
-            },
             'application/json': function(){
                 res.send({
-                    "notes": notes.merge(versions, { includeTag: false }),
-                    "pub_date": latest.published_at.toISOString()
+                    'notes': notes.merge(versions, { includeTag: false }),
+                    'pub_date': latest.published_at.toISOString()
                 });
             },
             'default': function() {
-                res.send(releaseNotes);
+                res.send(notes.merge(versions));
             }
         });
     })
@@ -389,6 +410,5 @@ Nuts.prototype.onAPIAccessControl = function(req, res, next) {
         next();
     }, next);
 };
-
 
 module.exports = Nuts;

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -1,6 +1,6 @@
 var _ = require('lodash');
-var Q = require('q');
 var semver = require('semver');
+var createError = require('http-errors');
 
 var platforms = require('./utils/platforms');
 
@@ -45,7 +45,7 @@ function normalizeVersion(release) {
     return {
         tag: normalizeTag(release.tag_name).split('-')[0],
         channel: extractChannel(release.tag_name),
-        notes: release.body || "",
+        notes: release.body || '',
         published_at: new Date(release.published_at),
         platforms: releasePlatforms
     };
@@ -64,7 +64,6 @@ function compareVersions(v1, v2) {
 
 function Versions(backend) {
     this.backend = backend;
-
 }
 
 // List versions normalized
@@ -93,7 +92,9 @@ Versions.prototype.filter = function(opts) {
         platform: null,
         channel: 'stable'
     });
-    if (opts.platform) opts.platform = platforms.detect(opts.platform);
+    if (opts.platform) {
+        opts.platform = platforms.detect(opts.platform);
+    }
 
     return this.list()
     .then(function(versions) {
@@ -117,7 +118,9 @@ Versions.prototype.resolve = function(opts) {
     return this.filter(opts)
     .then(function(versions) {
         var version = _.first(versions);
-        if (!version) throw new Error('Version not found: '+opts.tag);
+        if (!version) {
+            throw createError(404, 'Version not found: ' + opts.tag);
+        }
 
         return version;
     });
@@ -148,6 +151,5 @@ Versions.prototype.channels = function(opts) {
         return channels;
     });
 };
-
 
 module.exports = Versions;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "express-useragent": "0.1.9",
     "feed": "^0.3.0",
     "github-webhook-handler": "0.5.0",
+    "http-errors": "^1.5.0",
     "lodash": "3.7.0",
     "lru-diskcache": "1.1.1",
     "octocat": "0.10.2",
@@ -27,8 +28,10 @@
     "uuid": "2.0.1"
   },
   "devDependencies": {
+    "expect": "^1.20.2",
     "mocha": "1.18.2",
-    "should": "7.0.4"
+    "should": "7.0.4",
+    "supertest": "^2.0.0"
   },
   "bugs": {
     "url": "https://github.com/GitbookIO/nuts/issues"
@@ -45,6 +48,6 @@
   },
   "scripts": {
     "start": "node bin/web.js",
-    "test": "mocha --reporter list"
+    "test": "mocha --reporter spec --timeout 600000 ./test/all.js"
   }
 }

--- a/test/all.js
+++ b/test/all.js
@@ -1,0 +1,6 @@
+require('should');
+
+require('./platforms');
+require('./win-releases');
+
+require('./download');

--- a/test/all.js
+++ b/test/all.js
@@ -4,3 +4,4 @@ require('./platforms');
 require('./win-releases');
 
 require('./download');
+require('./update');

--- a/test/app.js
+++ b/test/app.js
@@ -1,0 +1,8 @@
+var nuts = require('../lib');
+
+var app = nuts.createApp({
+    repository: 'SamyPesse/nuts-testing',
+    token:      process.env.GITHUB_TOKEN
+});
+
+module.exports = app;

--- a/test/download.js
+++ b/test/download.js
@@ -1,0 +1,30 @@
+var testRequest = require('supertest');
+var app = require('./app');
+
+describe('Download', function() {
+    var agent;
+
+    before(function() {
+        agent = testRequest.agent(app);
+    });
+
+    describe('Latest version', function() {
+
+        it('should fail if no user-agent to detect platform', function(done) {
+            agent
+            .get('/')
+            .expect(400, done);
+        });
+
+        it('should download windows file', function(done) {
+            agent
+            .get('/')
+            .set('User-Agent', 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; Touch; rv:11.0) like Gecko')
+            .expect('Content-Length', '13')
+            .expect('Content-Disposition', 'attachment; filename=test.exe')
+            .expect(200, done);
+        });
+
+    });
+
+});

--- a/test/download.js
+++ b/test/download.js
@@ -1,10 +1,14 @@
 var request = require('supertest');
 var app = require('./app');
 
+var MAC_USERAGENT = 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_8; en-us)'
+        + ' AppleWebKit/530.19.2 (KHTML, like Gecko) Version/4.0.2 Safari/530.19';
+var WIN_USERAGENT = 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; Touch; rv:11.0) like Gecko';
+
 describe('Download', function() {
     var agent = request.agent(app);
 
-    describe('Latest version', function() {
+    describe('Latest version (/)', function() {
 
         it('should fail if no user-agent to detect platform', function(done) {
             agent
@@ -15,12 +19,39 @@ describe('Download', function() {
         it('should download windows file', function(done) {
             agent
             .get('/')
-            .set('User-Agent', 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; Touch; rv:11.0) like Gecko')
+            .set('User-Agent', WIN_USERAGENT)
             .expect('Content-Length', '13')
             .expect('Content-Disposition', 'attachment; filename=test.exe')
             .expect(200, done);
         });
 
+        it('should download OS X file as DMG', function(done) {
+            agent
+            .get('/')
+            .set('User-Agent', MAC_USERAGENT)
+            .expect('Content-Length', '19')
+            .expect('Content-Disposition', 'attachment; filename=test-osx.dmg')
+            .expect(200, done);
+        });
+
+    });
+
+    describe('Previous version (/download/version/)', function() {
+        it('should not have a windows file to download', function(done) {
+            agent
+            .get('/download/version/0.9.0')
+            .set('User-Agent', WIN_USERAGENT)
+            .expect(404, done);
+        });
+
+        it('should download OS X file as DMG', function(done) {
+            agent
+            .get('/download/version/0.9.0')
+            .set('User-Agent', MAC_USERAGENT)
+            .expect('Content-Length', '19')
+            .expect('Content-Disposition', 'attachment; filename=test-osx.dmg')
+            .expect(200, done);
+        });
     });
 
 });

--- a/test/download.js
+++ b/test/download.js
@@ -1,12 +1,8 @@
-var testRequest = require('supertest');
+var request = require('supertest');
 var app = require('./app');
 
 describe('Download', function() {
-    var agent;
-
-    before(function() {
-        agent = testRequest.agent(app);
-    });
+    var agent = request.agent(app);
 
     describe('Latest version', function() {
 

--- a/test/platforms.js
+++ b/test/platforms.js
@@ -1,4 +1,3 @@
-require('should');
 var platforms = require('../lib/utils/platforms');
 
 describe('Platforms', function() {

--- a/test/update.js
+++ b/test/update.js
@@ -1,0 +1,30 @@
+var request = require('supertest');
+var expect = require('expect');
+var app = require('./app');
+
+describe('Update', function() {
+    var agent = request.agent(app);
+
+    describe('Squirrel.Mac (OS X)', function() {
+
+        it('should return a 204 if using latest version', function(done) {
+            agent
+            .get('/update/osx/1.0.0')
+            .expect(204, done);
+        });
+
+        it('should return a 200 with json if using old version', function(done) {
+            agent
+            .get('/update/osx/0.9.0')
+            .expect('Content-Type', /json/)
+            .expect(function(res) {
+                expect(res.body.name).toBe('1.0.0');
+                expect(res.body.url).toExist();
+                expect(res.body.pub_date).toExist();
+            })
+            .expect(200, done);
+        });
+
+    });
+
+});

--- a/test/win-releases.js
+++ b/test/win-releases.js
@@ -1,4 +1,3 @@
-require('should');
 var winReleases = require('../lib/utils/win-releases');
 
 describe('Windows RELEASES', function() {


### PR DESCRIPTION
👷 WORK IN PROGRESS 🚧 

This PR adds more (and better) unit tests to Nuts. Basically download and updates will be correctly unit tested to avoid breaking changes when trying to contribute to the repository.

This PR will also add standard HTTP status codes to response, and fix #56.

I was hoping to move code to ES6 (cleaner code, especially for classes) and use Babel before npm releases, but I can't find a solution to make it work correctly while supporting the Heroku Deploy button (I'm open to ideas!).

I'll release a new version 🚀  as soon as all endpoints are correctly tested, and once I'm sure merging #95 did not break Nuts for GitBook and other devs.

XOXO 💕 