### PR TITLE
added option for download url prefix

### DIFF
--- a/bin/web.js
+++ b/bin/web.js
@@ -26,7 +26,8 @@ var myNuts = nuts.Nuts({
     timeout: process.env.VERSIONS_TIMEOUT,
     cache: process.env.VERSIONS_CACHE,
     refreshSecret: process.env.GITHUB_SECRET,
-    proxyAssets: !Boolean(process.env.DONT_PROXY_ASSETS)
+    proxyAssets: !Boolean(process.env.DONT_PROXY_ASSETS),
+    prefixUrl: process.env.PREFIX_URL
 });
 
 // Control access to API

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -13,8 +13,8 @@ var platforms = require('./utils/platforms');
 var winReleases = require('./utils/win-releases');
 var API_METHODS = require('./api');
 
-function getFullUrl(req) {
-    return req.protocol + '://' + req.get('host') + req.originalUrl;
+function getFullUrl(opts, req) {
+    return req.protocol + '://' + req.get('host') + opts.prefixUrl + req.originalUrl;
 }
 
 function Nuts(opts) {
@@ -210,7 +210,7 @@ Nuts.prototype.onUpdateRedirect = function(req, res, next) {
 // Updater used by OSX (Squirrel.Mac) and others
 Nuts.prototype.onUpdate = function(req, res, next) {
     var that = this;
-    var fullUrl = getFullUrl(req);
+    var fullUrl = getFullUrl(that.opts, req);
     var platform = req.params.platform;
     var channel = req.params.channel || '*';
     var tag = req.params.version;
@@ -256,7 +256,7 @@ Nuts.prototype.onUpdate = function(req, res, next) {
 Nuts.prototype.onUpdateWin = function(req, res, next) {
     var that = this;
 
-    var fullUrl = getFullUrl(req);
+    var fullUrl = getFullUrl(that.opts, req);
     var platform = 'win_32';
     var channel = req.params.channel || '*';
     var tag = req.params.version;


### PR DESCRIPTION
I installed Nuts behind an apache reverse proxy and mapping a subpath (e.g. http://download.myapp.com/nuts/) to the Nuts server. Afterwards nuts returned invalid urls like http://download.myapp.com/download instead of http://download.myapp.com/nuts/download. I added an environment variable PREFIX_URL for this use case. Maybe you too find it useful.