### PR TITLE
500 Internal Server Error is being used instead of 400 Bad Request

### DIFF
--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -147,7 +147,10 @@ Nuts.prototype.onDownload = function(req, res, next) {
             if (req.useragent.isLinux64) platform = platforms.LINUX_64;
         }
 
-        if (!platform) return next(new Error('No platform specified and impossible to detect one'));
+        if (!platform) {
+          res.status(400).send('No platform specified and impossible to detect one');
+          return;
+        }
     } else {
         platform = null;
     }
@@ -186,12 +189,17 @@ Nuts.prototype.onDownload = function(req, res, next) {
             });
         }
 
-        if (!asset) throw new Error("No download available for platform "+platform+" for version "+version.tag+" ("+(channel || "beta")+")");
+        if (!asset) {
+          res.status(400).send("No download available for platform "+platform+" for version "+version.tag+" ("+(channel || "beta")+")");
+          return;
+        }
 
         // Call analytic middleware, then serve
         return that.serveAsset(req, res, version, asset);
     })
-    .fail(next);
+    .fail(function() {
+      res.status(400).send("No download available for platform "+platform);
+    });
 };
 
 


### PR DESCRIPTION
For example, when no platform is specified:
https://github.com/GitbookIO/nuts/blob/master/lib/nuts.js#L150

5XX codes should be used for stuff like... github backend is down, mysql server connection failed, etc. Usually something unexpected and catastrophic. A bad request shouldn't throw this error. 5XX are server errors.

An error in this case should be a 4XX (client error).

I monitor my services for 5XX errors to detect if something is acting up, and caught these (unknown platform, unknown version, etc). I modified Nuts to respond with 400 Bad Request in these cases. 
