### PR TITLE
Use RELEASES-x64 for Windows x64

### DIFF
--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -257,7 +257,7 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
     var that = this;
 
     var fullUrl = getFullUrl(req);
-    var platform = 'win_32';
+    var platform = req.params.platform;
     var channel = req.params.channel || '*';
     var tag = req.params.version;
 
@@ -277,9 +277,20 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
         if (!latest) throw new Error("Version not found");
 
         // File exists
-        var asset = _.find(latest.platforms, {
-            filename: 'RELEASES'
-        });
+        var asset = null;
+
+        if (platform === platforms.WINDOWS_64) {
+            asset = _.find(latest.platforms, {
+                filename: 'RELEASES-x64'
+            });
+        }
+
+        if (!asset) {
+            asset = _.find(latest.platforms, {
+                filename: 'RELEASES'
+            });
+        }
+
         if (!asset) throw new Error("File not found");
 
        return that.backend.readAsset(asset)

--- a/lib/utils/platforms.js
+++ b/lib/utils/platforms.js
@@ -32,7 +32,14 @@ function detectPlatform(platform) {
     var prefix = "", suffix = "";
 
     // Detect NuGet/Squirrel.Windows files
-    if (name == 'releases' || hasSuffix(name, '.nupkg')) return platforms.WINDOWS_32;
+    if (name == 'releases-x64') return platforms.WINDOWS_64;
+    if (name == 'releases') return platforms.WINDOWS_32;
+    if (hasSuffix(name, '.nupkg')) {
+        if (_.contains(name, 'x64') || _.contains(name, 'amd64'))
+            return platforms.WINDOWS_64;
+        else
+            return platforms.WINDOWS_32;
+    }
 
     // Detect prefix: osx, widnows or linux
     if (_.contains(name, 'win')


### PR DESCRIPTION
This PR should fix https://github.com/GitbookIO/nuts/issues/32.

Support RELEASES-x64 for x64 platform in Windows.

- RELEASES-x64 (for x64)
- RELEASES (for ia-32)