### PR TITLE
Max Version for multi site server deployments

### DIFF
--- a/bin/web.js
+++ b/bin/web.js
@@ -26,6 +26,9 @@ var myNuts = nuts.Nuts({
     timeout: process.env.VERSIONS_TIMEOUT,
     cache: process.env.VERSIONS_CACHE,
     refreshSecret: process.env.GITHUB_SECRET,
+    // The maximum version to support in the RELEASES.
+    // For multi-environment deploys where each environment may be limited to a certain version of the app.
+    maxVersion: process.env.NUTS_MAX_VERSION,
     proxyAssets: !Boolean(process.env.DONT_PROXY_ASSETS)
 });
 

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -46,7 +46,7 @@ function Nuts(opts) {
 
     // Create backend
     this.backend = new (BACKENDS(this.opts.backend))(this, this.opts);
-    this.versions = new Versions(this.backend);
+    this.versions = new Versions(this.backend, this.opts.maxVersion);
 
     // Bind routes
     this.router.use(useragent.express());

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -62,18 +62,25 @@ function compareVersions(v1, v2) {
     return 0;
 }
 
-function Versions(backend) {
+function Versions(backend, maxVersion) {
     this.backend = backend;
-
+    this.maxVersion = null;
+    if(maxVersion){
+        this.maxVersion = normalizeTag(maxVersion);
+    }
 }
 
 // List versions normalized
 Versions.prototype.list = function() {
+    var maxVersion = this.maxVersion;
     return this.backend.releases()
     .then(function(releases) {
         return _.chain(releases)
             .map(normalizeVersion)
             .compact()
+            .filter(function(version){
+                return !maxVersion || semver.lte(version.tag, maxVersion);
+            })
             .sort(compareVersions)
             .value();
     });


### PR DESCRIPTION
This sets a max version on update requests, which allows for multi site server deployments where each server may be on a different version and will only support specific versions of the client.