### PR TITLE
Octocat version bump for Github Enterprise support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "github-webhook-handler": "0.5.0",
     "lodash": "3.7.0",
     "lru-diskcache": "1.1.1",
-    "octocat": "0.10.2",
+    "octocat": "0.12.1",
     "q": "1.2.0",
     "request": "2.60.0",
     "semver": "5.0.1",


### PR DESCRIPTION
The latest version of Octocat (0.12.1) has native support for Github Enterprise, you just need to provide the full URI. Within the context of Nuts this means setting `GITHUB_ENDPOINT` to something like `https://ghe.somecompany.com/api/v3`.