### PR TITLE
remove unneeded heroku Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: node bin/web.js


### PR DESCRIPTION
> To determine how to start your app, Heroku first looks for a Procfile. If no Procfile exists for a Node.js app, we will attempt to start a default web process via the start script in your package.json.

https://devcenter.heroku.com/articles/deploying-nodejs#specifying-a-start-script
