### PR TITLE
remove note about github token being optional

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -31,7 +31,6 @@ This service requires to be configured using environment variables:
 $ export PORT=6000
 
 # Access token for the GitHub API (requires permissions to access the repository)
-# If the repository is public you do not need to provide an access token
 # you can also use GITHUB_USERNAME and GITHUB_PASSWORD
 $ export GITHUB_TOKEN=...
 


### PR DESCRIPTION
If you don't specify `process.env.GITHUB_TOKEN`, then the server crashes with an error.
See https://github.com/GitbookIO/nuts/issues/76

This PR removes a comment from the guide that suggests the token is optional.