### PR TITLE
Change Blocked Example Port

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -28,7 +28,7 @@ This service requires to be configured using environment variables:
 
 ```
 # Set the port for the service
-$ export PORT=6000
+$ export PORT=5000
 
 # Access token for the GitHub API (requires permissions to access the repository)
 # If the repository is public you do not need to provide an access token


### PR DESCRIPTION
The example port (6000) is blocked on modern browsers to prevent cross-protocol scripting attacks to X11 which runs on the same port. Changed to a non-restrictive port (5000) so that people following the deployment guide will not end up with issues such as #126