### PR TITLE
Add escaping for bad platform string.

### DIFF
--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -186,7 +186,7 @@ Nuts.prototype.onDownload = function(req, res, next) {
             });
         }
 
-        if (!asset) throw new Error("No download available for platform "+platform+" for version "+version.tag+" ("+(channel || "beta")+")");
+        if (!asset) throw new Error("No download available for platform "+_.escape(platform)+" for version "+version.tag+" ("+(channel || "beta")+")");
 
         // Call analytic middleware, then serve
         return that.serveAsset(req, res, version, asset);
@@ -202,7 +202,7 @@ Nuts.prototype.onUpdateRedirect = function(req, res, next) {
         if (!req.query.version) throw new Error('Requires "version" parameter');
         if (!req.query.platform) throw new Error('Requires "platform" parameter');
 
-        return res.redirect('/update/'+req.query.platform+'/'+req.query.version);
+        return res.redirect('/update/'+_.escape(req.query.platform)+'/'+req.query.version);
     })
     .fail(next);
 };


### PR DESCRIPTION
Mitigates XSS on bad download URLs such as `https://YOUR.NUTS.URL/download/version/2.0.0/%3Cimg%20src=x%20onerror=alert(1)%3E`
and `https://YOUR.NUTS.URL/download/channel/alpha/%3Cimg%20src=x%20onerror=alert(1)%3E`

I don't see anywhere I could just insert a test for this in the existing suite.