### PR TITLE
setting content type for github webhook

### DIFF
--- a/docs/github.md
+++ b/docs/github.md
@@ -16,6 +16,10 @@ Where download.myapp.com, is the URL of your Nuts server.
 
 It'll refresh versions cache everytime you update a release on GitHub.
 
+### Content Type
+
+Make sure to set the Webhook content type to "application/json" instead of the default "application/x-www-form-urlencoded".
+
 ### Secret
 
 The GitHub Webhook secret can be configured as a environment variable on Nuts: `GITHUB_SECRET` (default value is `secret`).


### PR DESCRIPTION
GitHub sends webhooks with an "application/x-www-form-urlencoded" by default, but this crashes the nuts server because it's excepting the content type to be "application/json". There's a dropdown to change the content type, but since there's no error message in the Heroku logs it was a little tricky to track down why the webhook wasn't working:

![github config](https://i.imgur.com/rne0r6v.png)

 It'd be helpful to include this information in the docs so others don't get blocked by the same problem.