### PR TITLE
Fix for RELEASES URLs not containing the app name when using Nuts as an Express middleware

### DIFF
--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -2,6 +2,7 @@ var _ = require('lodash');
 var Q = require('q');
 var Feed = require('feed');
 var urljoin = require('urljoin.js');
+var url = require('url');
 var Understudy = require('understudy');
 var express = require('express');
 var useragent = require('express-useragent');
@@ -291,8 +292,7 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
                 // Change filename to use download proxy
                 .map(function(entry) {
                     var gitFilePath = (channel === '*' ? '../../../../' : '../../../../../../');
-                    entry.filename = urljoin(fullUrl, gitFilePath, '/download/'+entry.semver+'/'+entry.filename);
-
+                    entry.filename = urljoin(fullUrl.replace(url.parse(fullUrl).search, ''), gitFilePath, '/download/'+entry.semver+'/'+entry.filename);
                     return entry;
                 })
 


### PR DESCRIPTION
When search parameters are present in the URL that Electron sends to Nuts:
For example:
`http://localhost:4000/myApp/update/win32/1.0.0/RELEASES?arch=amd64`

The app name is being omitted:
`http://localhost:4000/download/1.1.0/my-app-1.1.0-full.nupkg`

Expected Result:
`http://localhost:4000/myApp/download/1.1.0/my-app-1.1.0-full.nupkg`

resolves #150