### PR TITLE
Authenticate requests

### DIFF
--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -35,7 +35,10 @@ function Nuts(opts) {
         preFetch: true,
 
         // Secret for GitHub webhook
-        refreshSecret: 'secret'
+        refreshSecret: 'secret',
+
+        // Authenticator for non-api endpoints
+        authHandler: undefined
     });
 
     // .init() is now a memoized version of ._init()
@@ -174,6 +177,9 @@ Nuts.prototype.onDownload = function(req, res, next) {
 
     // Serve downloads
     .then(function(version) {
+        if (this.opts.authHandler && !this.opts.authHandler(req, version))
+          return res.sendStatus(403)
+
         var asset;
 
         if (filename) {
@@ -233,6 +239,9 @@ Nuts.prototype.onUpdate = function(req, res, next) {
         var latest = _.first(versions);
         if (!latest || latest.tag == tag) return res.status(204).send('No updates');
 
+        if (this.opts.authHandler && !this.opts.authHandler(req, latest))
+          return res.sendStatus(403)
+
         var notesSlice = versions.slice(0, -1);
         if (versions.length === 1) {
             notesSlice = [versions[0]];
@@ -275,6 +284,9 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
         // Update needed?
         var latest = _.first(versions);
         if (!latest) throw new Error("Version not found");
+
+        if (this.opts.authHandler && !this.opts.authHandler(req, latest))
+          return res.sendStatus(403)
 
         // File exists
         var asset = _.find(latest.platforms, {
@@ -322,8 +334,10 @@ Nuts.prototype.onServeNotes = function(req, res, next) {
     })
     .then(function(versions) {
         var latest = _.first(versions);
-
         if (!latest) throw new Error('No versions matching');
+
+        if (this.opts.authHandler && !this.opts.authHandler(req, latest))
+          return res.sendStatus(403)
 
         res.format({
             'text/plain': function(){
@@ -364,13 +378,15 @@ Nuts.prototype.onServeVersionsFeed = function(req, res, next) {
     })
     .then(function(versions) {
         _.each(versions, function(version) {
-            feed.addItem({
+            if (!this.opts.authHandler || this.opts.authHandler(req, version)) {
+              feed.addItem({
                 title: version.tag,
-                link:  urljoin(fullUrl, '/../../../', '/download/version/'+version.tag),
+                link: urljoin(fullUrl, '/../../../', '/download/version/' + version.tag),
                 description: version.notes,
                 date: version.published_at,
                 author: []
-            });
+              });
+            }
         });
 
         res.set('Content-Type', 'application/atom+xml; charset=utf-8');

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -177,7 +177,7 @@ Nuts.prototype.onDownload = function(req, res, next) {
 
     // Serve downloads
     .then(function(version) {
-        if (that.opts.authHandler && !that.opts.authHandler(req, version))
+        if (that.opts.authHandler != undefined && !that.opts.authHandler(req, version))
           return res.sendStatus(403)
 
         var asset;
@@ -239,7 +239,7 @@ Nuts.prototype.onUpdate = function(req, res, next) {
         var latest = _.first(versions);
         if (!latest || latest.tag == tag) return res.status(204).send('No updates');
 
-        if (that.opts.authHandler && !that.opts.authHandler(req, latest))
+        if (that.opts.authHandler != undefined && !that.opts.authHandler(req, latest))
           return res.sendStatus(403)
 
         var notesSlice = versions.slice(0, -1);
@@ -285,7 +285,7 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
         var latest = _.first(versions);
         if (!latest) throw new Error("Version not found");
 
-        if (that.opts.authHandler && !that.opts.authHandler(req, latest))
+        if (that.opts.authHandler != undefined && !that.opts.authHandler(req, latest))
           return res.sendStatus(403)
 
         // File exists
@@ -336,7 +336,7 @@ Nuts.prototype.onServeNotes = function(req, res, next) {
         var latest = _.first(versions);
         if (!latest) throw new Error('No versions matching');
 
-        if (that.opts.authHandler && !that.opts.authHandler(req, latest))
+        if (that.opts.authHandler != undefined && !that.opts.authHandler(req, latest))
           return res.sendStatus(403)
 
         res.format({
@@ -378,7 +378,7 @@ Nuts.prototype.onServeVersionsFeed = function(req, res, next) {
     })
     .then(function(versions) {
         _.each(versions, function(version) {
-            if (!that.opts.authHandler || that.opts.authHandler(req, version)) {
+            if (that.opts.authHandler == undefined || that.opts.authHandler(req, version)) {
               feed.addItem({
                 title: version.tag,
                 link: urljoin(fullUrl, '/../../../', '/download/version/' + version.tag),

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -98,6 +98,13 @@ Nuts.prototype._init = function() {
     });
 }
 
+Nuts.prototype.checkAuth = async function(req, version) {
+    if (!this.opts.authHandler)
+        return true
+
+    return await this.opts.authHandler(req, version)
+}
+
 
 // Perform a hook using promised functions
 Nuts.prototype.performQ = function(name, arg, fn) {
@@ -176,8 +183,8 @@ Nuts.prototype.onDownload = function(req, res, next) {
     })
 
     // Serve downloads
-    .then(function(version) {
-        if (that.opts.authHandler != undefined && !that.opts.authHandler(req, version))
+    .then(async function(version) {
+        if (!(await that.checkAuth(req, version)))
           return res.sendStatus(403)
 
         var asset;
@@ -235,12 +242,12 @@ Nuts.prototype.onUpdate = function(req, res, next) {
             channel: channel
         });
     })
-    .then(function(versions) {
+    .then(async function(versions) {
         var latest = _.first(versions);
         if (!latest || latest.tag == tag) return res.status(204).send('No updates');
 
-        if (that.opts.authHandler != undefined && !that.opts.authHandler(req, latest))
-          return res.sendStatus(403)
+        if (!(await that.checkAuth(req, latest)))
+            return res.sendStatus(403)
 
         var notesSlice = versions.slice(0, -1);
         if (versions.length === 1) {
@@ -280,13 +287,13 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
             channel: channel
         });
     })
-    .then(function(versions) {
+    .then(async function(versions) {
         // Update needed?
         var latest = _.first(versions);
         if (!latest) throw new Error("Version not found");
 
-        if (that.opts.authHandler != undefined && !that.opts.authHandler(req, latest))
-          return res.sendStatus(403)
+        if (!(await that.checkAuth(req, latest)))
+            return res.sendStatus(403)
 
         // File exists
         var asset = _.find(latest.platforms, {
@@ -332,12 +339,12 @@ Nuts.prototype.onServeNotes = function(req, res, next) {
             channel: '*'
         });
     })
-    .then(function(versions) {
+    .then(async function(versions) {
         var latest = _.first(versions);
         if (!latest) throw new Error('No versions matching');
 
-        if (that.opts.authHandler != undefined && !that.opts.authHandler(req, latest))
-          return res.sendStatus(403)
+        if (!(await that.checkAuth(req, latest)))
+            return res.sendStatus(403)
 
         res.format({
             'text/plain': function(){
@@ -377,8 +384,8 @@ Nuts.prototype.onServeVersionsFeed = function(req, res, next) {
         });
     })
     .then(function(versions) {
-        _.each(versions, function(version) {
-            if (that.opts.authHandler == undefined || that.opts.authHandler(req, version)) {
+        _.each(versions, async function(version) {
+            if (await that.checkAuth(req, version)) {
               feed.addItem({
                 title: version.tag,
                 link: urljoin(fullUrl, '/../../../', '/download/version/' + version.tag),

--- a/lib/nuts.js
+++ b/lib/nuts.js
@@ -177,7 +177,7 @@ Nuts.prototype.onDownload = function(req, res, next) {
 
     // Serve downloads
     .then(function(version) {
-        if (this.opts.authHandler && !this.opts.authHandler(req, version))
+        if (that.opts.authHandler && !that.opts.authHandler(req, version))
           return res.sendStatus(403)
 
         var asset;
@@ -239,7 +239,7 @@ Nuts.prototype.onUpdate = function(req, res, next) {
         var latest = _.first(versions);
         if (!latest || latest.tag == tag) return res.status(204).send('No updates');
 
-        if (this.opts.authHandler && !this.opts.authHandler(req, latest))
+        if (that.opts.authHandler && !that.opts.authHandler(req, latest))
           return res.sendStatus(403)
 
         var notesSlice = versions.slice(0, -1);
@@ -285,7 +285,7 @@ Nuts.prototype.onUpdateWin = function(req, res, next) {
         var latest = _.first(versions);
         if (!latest) throw new Error("Version not found");
 
-        if (this.opts.authHandler && !this.opts.authHandler(req, latest))
+        if (that.opts.authHandler && !that.opts.authHandler(req, latest))
           return res.sendStatus(403)
 
         // File exists
@@ -336,7 +336,7 @@ Nuts.prototype.onServeNotes = function(req, res, next) {
         var latest = _.first(versions);
         if (!latest) throw new Error('No versions matching');
 
-        if (this.opts.authHandler && !this.opts.authHandler(req, latest))
+        if (that.opts.authHandler && !that.opts.authHandler(req, latest))
           return res.sendStatus(403)
 
         res.format({
@@ -378,7 +378,7 @@ Nuts.prototype.onServeVersionsFeed = function(req, res, next) {
     })
     .then(function(versions) {
         _.each(versions, function(version) {
-            if (!this.opts.authHandler || this.opts.authHandler(req, version)) {
+            if (!that.opts.authHandler || that.opts.authHandler(req, version)) {
               feed.addItem({
                 title: version.tag,
                 link: urljoin(fullUrl, '/../../../', '/download/version/' + version.tag),


### PR DESCRIPTION
This modification adds an `authHandler` options to authenticate requests.

```js
const nuts = Nuts({
  repository: "<repo name>",
  token: "<github token>",
  authHandler: function (req, version) {
    // Return whether the requesting user has permission to retrieve this release
  }
});
```

`authHandler` must return `true`/`false` or a promise resolving to `true`/`false`.