### PR TITLE
Add support for the darwin_arm64 platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ node_modules
 .env
 
 docs/_book/
+
+.vscode/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Nuts++ is a fork of [nuts](https://github.com/GitbookIO/nuts). It's simple (and smart) application to serve desktop-application releases.
 
 :exclamation: This version supports assets for the `darwin` platform and the arch `x64` and `arm64`.
+
 :exclamation: When you call `/update/<platform>/<version>`, in the version add the architecture, for instance `darwin-arm64`.
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Nuts
+# Nuts++
 
-Nuts is a simple (and smart) application to serve desktop-application releases.
+Nuts++ is a fork of [nuts](https://github.com/GitbookIO/nuts). It's simple (and smart) application to serve desktop-application releases.
+
+:exclamation: This version supports assets for the `darwin` platform and the arch `x64` and `arm64`.
+:exclamation: When you call `/update/<platform>/<version>`, in the version add the architecture, for instance `darwin-arm64`.
+
 
 ![Schema](./docs/schema.png)
 

--- a/lib/utils/platforms.js
+++ b/lib/utils/platforms.js
@@ -14,6 +14,7 @@ var platforms = {
     OSX: 'osx',
     OSX_32: 'osx_32',
     OSX_64: 'osx_64',
+    OSX_ARM64: 'osx_arm64',
     WINDOWS: 'windows',
     WINDOWS_32: 'windows_32',
     WINDOWS_64: 'windows_64',
@@ -65,7 +66,10 @@ function detectPlatform(platform) {
     if (_.contains(name, '32')
         || _.contains(name, 'ia32')
         || _.contains(name, 'i386')) suffix = '32';
+    
     if (_.contains(name, '64') || _.contains(name, 'x64') || _.contains(name, 'amd64')) suffix = '64';
+
+    if (_.contains(name, 'arm64')) suffix = 'arm64';
 
     suffix = suffix || (prefix == platforms.OSX? '64' : '32');
     return _.compact([prefix, suffix]).join('_');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "nuts-serve",
-  "version": "3.1.1",
+  "name": "nuts-serve-pp",
+  "version": "3.2.0",
   "description": "Server to make GitHub releases (private) available to download with Squirrel support",
   "main": "./lib/index.js",
   "homepage": "https://github.com/GitbookIO/nuts",


### PR DESCRIPTION
There's a problem when in GitHub there are two packages for the same platform but different architecture, for example:
```
myapp-darwin-arm64-1.1.372.zip
myapp-darwin-x64-1.1.372.zip
```

This PR adds support for platforms like:
```
http://localhost:3000/releases/update/darwin/1.0.1
http://localhost:3000/releases/update/darwin-x64/1.0.1
http://localhost:3000/releases/update/darwin-arm64/1.0.1
```